### PR TITLE
Retain user record partition keys

### DIFF
--- a/aggregator.go
+++ b/aggregator.go
@@ -31,14 +31,16 @@ func (a *Aggregator) Count() int {
 
 // Put record using `data` and `partitionKey`. This method is thread-safe.
 func (a *Aggregator) Put(data []byte, partitionKey string) {
-	// For now, all records in the aggregated record will have
-	// the same partition key.
-	// later, we will add shard-mapper same as the KPL use.
-	// see: https://github.com/a8m/kinesis-producer/issues/1
-	if len(a.pkeys) == 0 {
-		a.pkeys = []string{partitionKey}
-		a.nbytes += len([]byte(partitionKey))
-	}
+	// a8m: For now, all records in the aggregated record will have
+	//      the same partition key.
+	//      later, we will add shard-mapper same as the KPL use.
+	//      see: https://github.com/a8m/kinesis-producer/issues/1
+	// jawang35: In this fork I'm allowing user records to retain
+	//           their individual partition keys with the
+	//           understanding that shard-mapping is not implemented
+	//           like it is in the KPL.
+	a.pkeys = []string{partitionKey}
+	a.nbytes += len([]byte(partitionKey))
 	keyIndex := uint64(len(a.pkeys) - 1)
 
 	a.nbytes += partitionKeyIndexSize

--- a/aggregator_test.go
+++ b/aggregator_test.go
@@ -22,7 +22,7 @@ func TestSizeAndCount(t *testing.T) {
 	for i := 0; i < n; i++ {
 		a.Put(data, pkey)
 	}
-	assert(t, a.Size() == 5*n+5+8*n, "size should equal to the data and the partition-key")
+	assert(t, a.Size() == 5*n+5*n+8*n, "size should equal to the data and the partition-keys")
 	assert(t, a.Count() == n, "count should be equal to the number of Put calls")
 }
 


### PR DESCRIPTION
This PR reverts an existing implementation that forces all user records within the same aggregation to use the same partition key. User records will now retain their original partition keys so that consumers can expect conventional aggregation behavior.

The downside to this is that under the hood user records are not hashed and sent to the correct shards based on their partition keys. Rather the partition key of the first user record is used to determine the shard for the entire aggregation. This is happening anyways but could make debugging confusing if we have problems with overloading specific shards and not equally distributing put requests. So long as there is enough uniqueness in our partition keys I believe this won't be a problem.