### PR TITLE
Fix max record size check

### DIFF
--- a/aggregator.go
+++ b/aggregator.go
@@ -31,14 +31,6 @@ func (a *Aggregator) Count() int {
 
 // Put record using `data` and `partitionKey`. This method is thread-safe.
 func (a *Aggregator) Put(data []byte, partitionKey string) {
-	// a8m: For now, all records in the aggregated record will have
-	//      the same partition key.
-	//      later, we will add shard-mapper same as the KPL use.
-	//      see: https://github.com/a8m/kinesis-producer/issues/1
-	// jawang35: In this fork I'm allowing user records to retain
-	//           their individual partition keys with the
-	//           understanding that shard-mapping is not implemented
-	//           like it is in the KPL.
 	a.pkeys = append(a.pkeys, partitionKey)
 	a.nbytes += len([]byte(partitionKey))
 	keyIndex := uint64(len(a.pkeys) - 1)

--- a/aggregator.go
+++ b/aggregator.go
@@ -35,6 +35,7 @@ func (a *Aggregator) Put(data []byte, partitionKey string) {
 	a.nbytes += len([]byte(partitionKey))
 	keyIndex := uint64(len(a.pkeys) - 1)
 
+	a.nbytes++ // message index and wire type
 	a.nbytes += partitionKeyIndexSize
 	a.buf = append(a.buf, &Record{
 		Data:              data,

--- a/aggregator_test.go
+++ b/aggregator_test.go
@@ -22,7 +22,7 @@ func TestSizeAndCount(t *testing.T) {
 	for i := 0; i < n; i++ {
 		a.Put(data, pkey)
 	}
-	assert(t, a.Size() == 5*n+5*n+8*n, "size should equal to the data and the partition-keys")
+	assert(t, a.Size() == n+5*n+5*n+8*n, "size should equal to the data and the partition-keys")
 	assert(t, a.Count() == n, "count should be equal to the number of Put calls")
 }
 

--- a/producer.go
+++ b/producer.go
@@ -84,7 +84,7 @@ func (p *Producer) Put(data []byte, partitionKey string) error {
 		}
 	} else {
 		p.Lock()
-		needToDrain := nbytes+p.aggregator.Size()+md5.Size+len(magicNumber)+partitionKeyIndexSize > maxRecordSize || p.aggregator.Count() >= p.AggregateBatchCount
+		needToDrain := nbytes+p.aggregator.Size()+md5.Size+len(magicNumber)+partitionKeyIndexSize >= maxRecordSize || p.aggregator.Count() >= p.AggregateBatchCount
 		var (
 			record *kinesis.PutRecordsRequestEntry
 			err    error

--- a/producer.go
+++ b/producer.go
@@ -84,7 +84,7 @@ func (p *Producer) Put(data []byte, partitionKey string) error {
 		}
 	} else {
 		p.Lock()
-		needToDrain := nbytes+p.aggregator.Size()+md5.Size+len(magicNumber)+partitionKeyIndexSize >= maxRecordSize || p.aggregator.Count() >= p.AggregateBatchCount
+		needToDrain := nbytes+p.aggregator.Size()+md5.Size+len(magicNumber)+partitionKeyIndexSize > maxRecordSize || p.aggregator.Count() >= p.AggregateBatchCount
 		var (
 			record *kinesis.PutRecordsRequestEntry
 			err    error


### PR DESCRIPTION
This PR fixes a bug where the protobuf wire type wasn't included in the size of the message and therefore was causing `Member must have length less than or equal to 1048576` errors in edge cases. See https://github.com/awslabs/kinesis-aggregation/issues/30 for information.